### PR TITLE
fix: virtualize large policy groups

### DIFF
--- a/src/pages/Policies/components/PolicyGroup.tsx
+++ b/src/pages/Policies/components/PolicyGroup.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/utils/shadcn'
 import { mutatePolicyPerformanceResults } from '../usePolicyPerformance'
 
 interface PolicyGroupProps {
+  columnCount: number
   policyGroupName: string
   policyGroup: Policy[]
   policyPerformanceResults?: PolicyBenchmarkResults
@@ -98,6 +99,7 @@ const PolicyCard = React.memo<PolicyCardProps>(
 PolicyCard.displayName = 'PolicyCard'
 
 const PolicyGroup: React.FC<PolicyGroupProps> = ({
+  columnCount,
   policyGroupName,
   policyGroup,
   policyPerformanceResults,
@@ -269,7 +271,6 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
 
   const renderVirtualizedPolicyList = useCallback(
     (width: number, height: number) => {
-      const columnCount = width >= 768 ? 4 : width >= 560 ? 3 : 2
       const columnWidth =
         (width - POLICY_CARD_GAP * (columnCount - 1)) / columnCount
       const rowCount = Math.ceil(policyGroup.length / columnCount)
@@ -315,7 +316,7 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
         />
       )
     },
-    [policyGroup, renderPolicyCard],
+    [columnCount, policyGroup, renderPolicyCard],
   )
 
   useEffect(() => {

--- a/src/pages/Policies/components/PolicyGroup.tsx
+++ b/src/pages/Policies/components/PolicyGroup.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2Icon, ZapIcon } from 'lucide-react'
+import { AutoSizer, List, ListRowRenderer } from 'react-virtualized'
 import useIsInViewport from 'use-is-in-viewport'
 
 import { StatusChip } from '@/components/StatusChip'
@@ -28,6 +29,10 @@ type LocalLatency = {
   error?: string | null
 }
 
+const VIRTUALIZED_POLICY_THRESHOLD = 80
+const POLICY_CARD_GAP = 16
+const POLICY_CARD_ROW_HEIGHT = 128
+
 const latencyResultStyle = (latency: number) => {
   if (latency < 0) {
     return 'error'
@@ -38,6 +43,60 @@ const latencyResultStyle = (latency: number) => {
   }
 }
 
+interface PolicyCardProps {
+  isSelected: boolean
+  latency?: LocalLatency
+  policy: Policy
+  onSelect: (name: string) => void
+}
+
+const PolicyCard = React.memo<PolicyCardProps>(
+  ({ isSelected, latency, policy, onSelect }) => {
+    const typeDescription = policy.typeDescription.toUpperCase()
+
+    return (
+      <div
+        className={cn(
+          'flex h-full flex-col bg-muted rounded-xl border px-3 py-3 md:px-4 md:py-3 cursor-pointer hover:bg-neutral-100 dark:hover:bg-black/90 transition-colors ease-in-out duration-200 justify-between gap-2 md:gap-3 ring-1 ring-black/[0.03] dark:ring-white/[0.04]',
+          isSelected &&
+            'bg-blue-500 text-white hover:bg-blue-500 dark:hover:bg-blue-500',
+        )}
+        data-policy-line-hash={policy.lineHash}
+        onClick={() => onSelect(policy.name)}
+      >
+        <div className="min-h-0">
+          <div className="text-xs mb-1 truncate">{typeDescription}</div>
+
+          <div className="text-xs sm:text-sm font-bold leading-snug whitespace-break-spaces break-all line-clamp-3">
+            {policy.name}
+          </div>
+        </div>
+
+        <div className="flex min-h-6">
+          {latency && latency.latency > 0 && (
+            <StatusChip
+              className="truncate"
+              size="sm"
+              variant={latencyResultStyle(latency.latency)}
+              text={latency.latency + 'ms'}
+            />
+          )}
+          {!typeDescription.includes('REJECT') && latency?.latency === -1 && (
+            <StatusChip
+              className="truncate"
+              size="sm"
+              variant="error"
+              text={latency.error || 'Error'}
+            />
+          )}
+        </div>
+      </div>
+    )
+  },
+)
+
+PolicyCard.displayName = 'PolicyCard'
+
 const PolicyGroup: React.FC<PolicyGroupProps> = ({
   policyGroupName,
   policyGroup,
@@ -46,7 +105,7 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
   const { t } = useTranslation()
   const [isInViewport, targetRef] = useIsInViewport({ threshold: 10 })
   const [selection, setSelection] = useState<string>()
-  const [latencies, setLatencies] = useState<{
+  const [localLatencies, setLocalLatencies] = useState<{
     [name: string]: LocalLatency
   }>({})
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -58,9 +117,9 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
     }).then((res) => res.policy)
   }, [policyGroupName])
 
-  useEffect(() => {
+  const performanceLatencies = useMemo(() => {
     if (!policyPerformanceResults) {
-      return
+      return {}
     }
 
     const latencies: {
@@ -68,29 +127,26 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
     } = {}
 
     policyGroup.forEach((policy) => {
-      Object.keys(policyPerformanceResults).forEach((key) => {
-        if (policy.lineHash === key) {
-          if (!latencies[policy.name]) {
-            latencies[policy.name] = {
-              latency: 0,
-            }
-          }
+      if (!policy.lineHash) return
 
-          latencies[policy.name].latency =
-            policyPerformanceResults[key].lastTestScoreInMS === 0 &&
-            policyPerformanceResults[key].lastTestErrorMessage !== null
-              ? -1
-              : Number(
-                  policyPerformanceResults[key].lastTestScoreInMS.toFixed(0),
-                )
-          latencies[policy.name]['error'] =
-            policyPerformanceResults[key].lastTestErrorMessage
-        }
-      })
+      const result = policyPerformanceResults[policy.lineHash]
+      if (!result) return
+
+      latencies[policy.name] = {
+        latency:
+          result.lastTestScoreInMS === 0 && result.lastTestErrorMessage !== null
+            ? -1
+            : Number(result.lastTestScoreInMS.toFixed(0)),
+        error: result.lastTestErrorMessage,
+      }
     })
 
-    setLatencies(latencies)
+    return latencies
   }, [policyGroup, policyPerformanceResults])
+
+  const latencies = policyPerformanceResults
+    ? performanceLatencies
+    : localLatencies
 
   const selectPolicy = useCallback(
     (name: string) => {
@@ -186,7 +242,7 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
             })
           }
 
-          setLatencies(latencies)
+          setLocalLatencies(latencies)
         })
         .catch((err) => {
           console.error(err)
@@ -196,6 +252,70 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
         })
     },
     [isTesting, policyPerformanceResults, refreshSelection],
+  )
+
+  const renderPolicyCard = useCallback(
+    (policy: Policy) => (
+      <PolicyCard
+        key={policy.name}
+        policy={policy}
+        isSelected={selection === policy.name}
+        latency={latencies[policy.name]}
+        onSelect={selectPolicy}
+      />
+    ),
+    [latencies, selectPolicy, selection],
+  )
+
+  const renderVirtualizedPolicyList = useCallback(
+    (width: number, height: number) => {
+      const columnCount = width >= 768 ? 4 : width >= 560 ? 3 : 2
+      const columnWidth =
+        (width - POLICY_CARD_GAP * (columnCount - 1)) / columnCount
+      const rowCount = Math.ceil(policyGroup.length / columnCount)
+
+      const rowRenderer: ListRowRenderer = ({ index, key, style }) => {
+        const startIndex = index * columnCount
+        const rowPolicies = policyGroup.slice(
+          startIndex,
+          startIndex + columnCount,
+        )
+
+        return (
+          <div
+            key={key}
+            style={{
+              ...style,
+              display: 'flex',
+              gap: POLICY_CARD_GAP,
+              paddingBottom: POLICY_CARD_GAP,
+            }}
+          >
+            {rowPolicies.map((policy) => (
+              <div
+                key={policy.name}
+                style={{ width: columnWidth, height: POLICY_CARD_ROW_HEIGHT }}
+              >
+                {renderPolicyCard(policy)}
+              </div>
+            ))}
+          </div>
+        )
+      }
+
+      return (
+        <List
+          width={width}
+          height={height}
+          rowCount={rowCount}
+          rowHeight={POLICY_CARD_ROW_HEIGHT + POLICY_CARD_GAP}
+          rowRenderer={rowRenderer}
+          overscanRowCount={3}
+          style={{ outline: 'none' }}
+        />
+      )
+    },
+    [policyGroup, renderPolicyCard],
   )
 
   useEffect(() => {
@@ -233,54 +353,19 @@ const PolicyGroup: React.FC<PolicyGroupProps> = ({
       </CardHeader>
 
       <CardContent className="p-0">
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {policyGroup.map((policy) => {
-            const typeDescription = policy.typeDescription.toUpperCase()
-
-            return (
-              <div
-                className={cn(
-                  'flex flex-col bg-muted rounded-xl border px-3 py-3 md:px-4 md:py-3 cursor-pointer hover:bg-neutral-100 dark:hover:bg-black/90 transition-colors ease-in-out duration-200 justify-between gap-2 md:gap-3 ring-1 ring-black/[0.03] dark:ring-white/[0.04]',
-                  selection === policy.name &&
-                    'bg-blue-500 text-white hover:bg-blue-500 dark:hover:bg-blue-500',
-                )}
-                key={policy.name}
-                data-policy-line-hash={policy.lineHash}
-                onClick={() => selectPolicy(policy.name)}
-              >
-                <div>
-                  <div className="text-xs mb-1 truncate">{typeDescription}</div>
-
-                  <div className="text-xs sm:text-sm font-bold leading-snug whitespace-break-spaces break-all">
-                    {policy.name}
-                  </div>
-                </div>
-
-                <div className="flex">
-                  {latencies[policy.name]?.latency > 0 && (
-                    <StatusChip
-                      className="truncate"
-                      size="sm"
-                      variant={latencyResultStyle(
-                        latencies[policy.name].latency,
-                      )}
-                      text={latencies[policy.name].latency + 'ms'}
-                    />
-                  )}
-                  {!typeDescription.includes('REJECT') &&
-                    latencies[policy.name]?.latency === -1 && (
-                      <StatusChip
-                        className="truncate"
-                        size="sm"
-                        variant="error"
-                        text={latencies[policy.name].error || 'Error'}
-                      />
-                    )}
-                </div>
-              </div>
-            )
-          })}
-        </div>
+        {policyGroup.length > VIRTUALIZED_POLICY_THRESHOLD ? (
+          <div className="h-[55vh] min-h-80 max-h-[640px]">
+            <AutoSizer>
+              {({ width, height }) =>
+                renderVirtualizedPolicyList(width, height)
+              }
+            </AutoSizer>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {policyGroup.map(renderPolicyCard)}
+          </div>
+        )}
       </CardContent>
     </div>
   )

--- a/src/pages/Policies/index.tsx
+++ b/src/pages/Policies/index.tsx
@@ -2,6 +2,7 @@ import React, { createRef, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from '@emotion/react'
 import useSWR from 'swr'
+import { useMediaQuery } from 'usehooks-ts'
 
 import BackButton from '@/components/BackButton'
 import { TypographyH3 } from '@/components/ui/typography'
@@ -32,6 +33,9 @@ export const Component: React.FC = () => {
   )
   const headerRef = useRef<HTMLDivElement>(null)
   const { data: policyPerformanceResults } = usePolicyPerformance()
+  const isMediumViewport = useMediaQuery('(min-width: 768px)')
+  const isLargeViewport = useMediaQuery('(min-width: 1024px)')
+  const policyColumnCount = isLargeViewport ? 4 : isMediumViewport ? 3 : 2
 
   const scrollToRef = (index: number) => {
     const target = refs[index].current
@@ -101,6 +105,7 @@ export const Component: React.FC = () => {
                   policyGroupName={policy}
                   policyGroup={policyGroups[policy]}
                   policyPerformanceResults={policyPerformanceResults}
+                  columnCount={policyColumnCount}
                 />
               </div>
             )

--- a/src/pages/Policies/index.tsx
+++ b/src/pages/Policies/index.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useRef } from 'react'
+import React, { createRef, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from '@emotion/react'
 import useSWR from 'swr'
@@ -26,9 +26,10 @@ export const Component: React.FC = () => {
     fetcher,
   )
   const policyGroupNames = (policies && policies['policy-groups']) || []
-  const refs = policyGroupNames.map(() => {
-    return createRef<HTMLDivElement>()
-  })
+  const refs = useMemo(
+    () => policyGroupNames.map(() => createRef<HTMLDivElement>()),
+    [policyGroupNames],
+  )
   const headerRef = useRef<HTMLDivElement>(null)
   const { data: policyPerformanceResults } = usePolicyPerformance()
 


### PR DESCRIPTION
## Summary

- Virtualize policy groups with many nodes to avoid rendering every policy card at once.
- Memoize policy cards and keep policy group refs stable across renders.
- Replace the benchmark latency matching double loop with direct `lineHash` lookups.

## Why

Opening a policy group with a large number of nodes could freeze the browser because the page created all node cards, event handlers, and latency mappings in one render pass.

## Testing

- `vp fmt src/pages/Policies/index.tsx src/pages/Policies/components/PolicyGroup.tsx --check`
- `vp lint src/pages/Policies/index.tsx src/pages/Policies/components/PolicyGroup.tsx`
- `tsc --noEmit`
- `vp test`